### PR TITLE
Fixed run-time error when using custom compiler

### DIFF
--- a/src/main/python/fobis/Compiler.py
+++ b/src/main/python/fobis/Compiler.py
@@ -91,7 +91,7 @@ class Compiler(object):
       elif self.compiler.lower() == 'opencoarrays-gnu':
         self._opencoarrays_gnu()
       elif self.compiler.lower() == 'custom':
-        pass  # set by user options
+        self._custom()
       else:
         self._gnu()
     # overriding default values if passed
@@ -176,6 +176,21 @@ class Compiler(object):
     self._coarray = ['', '']
     self._coverage = ['-ftest-coverage -fprofile-arcs', '-fprofile-arcs']
     self._profile = ['-pg', '-pg']
+    return
+
+  def _custom(self):
+    """Set compiler defaults to be empty."""
+    self.compiler = ''
+    self.fcs = ''
+    self.cflags = ''
+    self.lflags = ''
+    self.preproc = ''
+    self.modsw = ''
+    self._mpi = ''
+    self._openmp = ''
+    self._coarray = ''
+    self._coverage = ''
+    self._profile = ''
     return
 
   def _set_fcs(self):


### PR DESCRIPTION
When using a custom compiler, there was the error  
```
Traceback (most recent call last):
  File "/home/chris/.local/bin/FoBiS.py", line 21, in <module>
    main()
  File "/home/chris/.local/lib/python2.7/site-packages/fobis/fobis.py", line 39, in main
    run_fobis()
  File "/home/chris/.local/lib/python2.7/site-packages/fobis/fobis.py", line 52, in run_fobis
    configuration = FoBiSConfig(fake_args=fake_args)
  File "/home/chris/.local/lib/python2.7/site-packages/fobis/FoBiSConfig.py", line 60, in __init__
    self._postinit()
  File "/home/chris/.local/lib/python2.7/site-packages/fobis/FoBiSConfig.py", line 116, in _postinit
    self._check_cflags_heritage()
  File "/home/chris/.local/lib/python2.7/site-packages/fobis/FoBiSConfig.py", line 95, in _check_cflags_heritage
    cflags = Builder.get_cflags(cliargs=self.cliargs)
  File "/home/chris/.local/lib/python2.7/site-packages/fobis/Builder.py", line 124, in get_cflags
    return Compiler(cliargs=cliargs).cflags
  File "/home/chris/.local/lib/python2.7/site-packages/fobis/Compiler.py", line 114, in __init__
    self._set_cflags()
  File "/home/chris/.local/lib/python2.7/site-packages/fobis/Compiler.py", line 204, in _set_cflags
    if self.preproc is not None:
AttributeError: 'Compiler' object has no attribute 'preproc'
```
This was due to the `preproc` attribute not having been created in that case. I've added the code to create all of the compiler attributes and set them to `''` when a custom compiler is used.