### PR TITLE
support windows cmd

### DIFF
--- a/src/main/python/fobis/Builder.py
+++ b/src/main/python/fobis/Builder.py
@@ -394,7 +394,7 @@ class Builder(object):
       if mklib.lower() == 'shared':
         link_cmd = self.cmd_link + " " + link_cmd + " -o " + lib
       elif mklib.lower() == 'static':
-        link_cmd = "ar -rcs " + lib + " " + link_cmd + " ; ranlib " + lib
+        link_cmd = "ar -rcs " + lib + " " + link_cmd + " \n ranlib " + lib
     return link_cmd, lib
 
   def _get_libs_link_command(self, file_to_build, exclude_programs=False, nomodlibs=None, submodules=None, mklib=None):


### PR DESCRIPTION
Hi, great tool!!! Unfortunately I have to develop for a windows community. But the build process fails when linking a static library because you cannot join multiple commands with ';' on a windows cmd. I propose to connect the two commands with '\n' or to call the two commands ('ar' and 'ranlib') separately.