### PR TITLE
fix issue on windows

### DIFF
--- a/src/main/python/FoBiS.py
+++ b/src/main/python/FoBiS.py
@@ -17,5 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with FoBiS.py. If not, see <http://www.gnu.org/licenses/>.
 from fobis.fobis import main
+import sys
+
+
+if sys.platform == 'win32':
+  import colorama
+  colorama.init(convert=True)
+
+
 if __name__ == '__main__':
   main()

--- a/src/main/scripts/FoBiS.py
+++ b/src/main/scripts/FoBiS.py
@@ -17,5 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with FoBiS.py. If not, see <http://www.gnu.org/licenses/>.
 from fobis.fobis import main
+import sys
+
+
+if sys.platform == 'win32':
+  import colorama
+  colorama.init(convert=True)
+
+
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
The ANSI escape sequences for colored output create some issues when using FoBiS.py on windows.
I added color support for windows cmd which resolves these issues.

I found file 'FoBiS.py' twice in the src folder so I changed both of them..

Best
Matthias