### PR TITLE
Removed multiprocessing from list of required packages

### DIFF
--- a/src/main/scripts/setup.py
+++ b/src/main/scripts/setup.py
@@ -31,4 +31,4 @@ if __name__ == '__main__':
         extras_require        = { 'PreForM.py':  ["PreForM.py>=v1.1.1"],
                                   'FORD': ["FORD>=1.1.0"],
                                   'graphviz': ["graphviz>=0.4.2"]},
-        install_requires      = [ "multiprocessing", "future", "configparser" ])
+        install_requires      = [ "future", "configparser" ])


### PR DESCRIPTION
multiprocessing is a built in module in python. There is a package on pypi called multiprocessing, but this is a backport for python 2.4/2.5. The pypi package does not work on python3, and inclusion of it in the list of required packages thus causes pip to fail when installing FoBiS.py in python3.
See also #117 