### PR TITLE
Gcov crash fix

### DIFF
--- a/src/main/python/fobis/Gcov.py
+++ b/src/main/python/fobis/Gcov.py
@@ -221,7 +221,10 @@ class Gcov(object):
               ptype = proc_matching.group('ptype').strip()
               pname = proc_matching.group('pname').strip()
               if cov_num != '#####' and cov_num != '-':
-                pcov = int(cov_num)
+                try:
+                  pcov = int(cov_num.strip('*'))
+                except ValueError:
+                  pcov = 0
               else:
                 pcov = 0
               if cov_num != '-':  # needed due to abstract iterfaces


### PR DESCRIPTION
There is some situation where `cov_num` contains an '*' character, which causes a crash. 

see: https://github.com/jacobwilliams/json-fortran/issues/595

The fix strips out '*' characters before converting to an int.